### PR TITLE
Refactor Buttons with Icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@popperjs/core": "^2.6.0",
     "animejs": "^3.2.1",
-    "material-icons": "^0.5.4",
     "vue": "^3.0.7",
     "vue-router": "^4.0.3"
   },

--- a/src/lib/components/SdButton/SdButton.vue
+++ b/src/lib/components/SdButton/SdButton.vue
@@ -127,8 +127,7 @@ export default defineComponent({
     const rootClasses = computed(() => {
       return {
         'is--disabled': props.disabled,
-        'is--rounded': props.rounded,
-        'is--pill': props.pill,
+        'is--pill': props.pill || props.rounded,
         'is--flat': props.flat,
         'is--outline': props.outline,
         'is--icon-only': props.iconOnly,
@@ -149,7 +148,7 @@ export default defineComponent({
     })
 
     const sizeClass = computed(() => {
-      return `is--${props.size}`
+      return `sd--button--${props.size}`
     })
 
     const themeClass = computed(() => {
@@ -242,78 +241,75 @@ export default defineComponent({
   &:last-child {
     margin-right: 0;
   }
+  &--xs {
+    .sd--button__content{
+      @extend %button-content;
+      padding: spacing(offset, xs);
 
-   &.is {
-    &--xs {
-      .sd--button__content{
-        @extend %button-content;
-        padding: spacing(offset, xs);
+    }
+    .sd--icon{
+      @extend %icons;
+      line-height: 20px;
 
-      }
+    }
+    font-size: rem(11);
+    min-height: 20px;
+  }
+
+  &--sm {
+    font-size: rem(14);
+    min-height: 26px;
+    .sd--button__content{
+      line-height: spacing(inset, sm) * 2;
+      @extend %button-content;
+      padding: spacing(offset, sm);
+    }
+    &.is--icon-only{
       .sd--icon{
-        @extend %icons;
-        line-height: 20px;
-
-      }
-      font-size: rem(11);
-      min-height: 20px;
-    }
-
-    &--sm {
-      font-size: rem(14);
-      min-height: 32px;
-      .sd--button__content{
+        width: 26px;
         line-height: spacing(inset, sm) * 2;
-        @extend %button-content;
-        padding: spacing(inset, sm);
-      }
-      &.is--icon-only{
-        .sd--icon{
-          width: spacing(inset, sm) * 2;
-          line-height: spacing(inset, sm) * 2;
-        }
       }
     }
+  }
 
-    &--md {
-      font-size: rem(16);
-      min-height: spacing(inset, md);
-      .sd--button__content {
-        @extend %button-content;
-        padding: spacing(offset, md);
-      }
-      &.is--icon-only{
-        .sd--icon {
-          width: spacing(inset, md) * 2;
-        }
+  &--md {
+    font-size: rem(16);
+    min-height: 32px;
+    .sd--button__content {
+      @extend %button-content;
+      padding: spacing(offset, md);
+    }
+    &.is--icon-only{
+      .sd--icon {
+        width: 32px;
       }
     }
+  }
 
-    &--lg {
-      font-size: rem(18);
-      min-height: spacing(inset, lg) * 2;
-      .sd--button__content {
-        @extend %button-content;
-        padding: spacing(offset, lg);
-      }
-      &.is--icon-only {
-        .sd--icon {
-          width: spacing(inset, lg) * 2;
-        }
+  &--lg {
+    font-size: rem(18);
+    min-height: 50px;
+    .sd--button__content {
+      @extend %button-content;
+      padding: spacing(offset, lg);
+    }
+    &.is--icon-only {
+      .sd--icon {
+        width: 50px;
       }
     }
+  }
 
-    &--xl {
-      font-size: rem(24);
-      min-height: spacing(inset, lg) * 2;
-      .sd--button__content {
-        @extend %button-content;
-        padding: spacing(offset, xl);
-      }
-      &.is--icon-only {
-        .sd--icon {
-          width: spacing(inset, lg) * 2;
-        }
+  &--xl {
+    font-size: rem(24);
+    min-height: 64px;
+    .sd--button__content {
+      @extend %button-content;
+      padding: spacing(offset, xl);
+    }
+    &.is--icon-only {
+      .sd--icon {
+        width: 64px;
       }
     }
   }
@@ -402,10 +398,6 @@ export default defineComponent({
         box-shadow: 0 0 0 5px var(--#{$state}-highlight);
         transition: box-shadow .2s ease-out;
       }
-    }
-
-    &.is--rounded {
-      border-radius: 30px;
     }
 
     &.is--pill {

--- a/src/lib/components/SdButton/SdButton.vue
+++ b/src/lib/components/SdButton/SdButton.vue
@@ -76,9 +76,17 @@ export default defineComponent({
       default: false
     },
     /**
-     * Show an icon in the button
+     * Sets an icon in the button
     */
     icon: String,
+    /**
+     * Changes the icon type family between Material icons types.
+     * @values round, sharp, two-tone
+    */
+    iconFamily: String,
+    /**
+     * Sets the icon at the end of the button.
+    */
     iconEnd: String,
     /**
      * Use when there is no other content in the button other than an icon.
@@ -161,7 +169,7 @@ export default defineComponent({
           ref: root,
           id: props.id,
           type: !props.href && (props.type || 'button'),
-          class: ['sd--button', themeClass.value, rootClasses.value],
+          class: ['sd--button', themeClass.value, rootClasses.value, sizeClass.value],
           href: props.href,
           disabled: props.disabled,
           style: alignmentStyle.value
@@ -169,16 +177,18 @@ export default defineComponent({
         [
           props.icon && h(SdIcon, {
             name: props.icon,
+            family: props.iconFamily,
             size: props.size
           }),
           !props.iconOnly && h('div',
             {
-              class: ['sd--button__content', sizeClass.value]
+              class: 'sd--button__content'
             },
             slots
           ),
           props.iconEnd && h(SdIcon, {
             name: props.iconEnd,
+            family: props.iconFamily,
             size: props.size
           })
         ]
@@ -192,6 +202,27 @@ export default defineComponent({
 @import '../../scss/mixins';
 @import '../../scss/functions';
 @import '../SdElevation/mixins';
+
+%button-content{
+  position: relative;
+  z-index: 10;
+  line-height: 1;
+  transition: font-size .23s;
+  padding-top:8px;
+  padding-bottom:8px;
+  display:flex;
+  align-items: center;;
+}
+%icons{
+  width: 32px;
+  position: relative;
+  & + .sd--button__content {
+    padding-left: 0px;
+  }
+  &:only-child {
+    margin-left:0!important;
+  }
+}
 
 .sd--button {
   touch-action: manipulation;
@@ -212,54 +243,96 @@ export default defineComponent({
     margin-right: 0;
   }
 
+   &.is {
+    &--xs {
+      .sd--button__content{
+        @extend %button-content;
+        padding: spacing(offset, xs);
+
+      }
+      .sd--icon{
+        @extend %icons;
+        line-height: 20px;
+
+      }
+      font-size: rem(11);
+      min-height: 20px;
+    }
+
+    &--sm {
+      font-size: rem(14);
+      min-height: 32px;
+      .sd--button__content{
+        line-height: spacing(inset, sm) * 2;
+        @extend %button-content;
+        padding: spacing(inset, sm);
+      }
+      &.is--icon-only{
+        .sd--icon{
+          width: spacing(inset, sm) * 2;
+          line-height: spacing(inset, sm) * 2;
+        }
+      }
+    }
+
+    &--md {
+      font-size: rem(16);
+      min-height: spacing(inset, md);
+      .sd--button__content {
+        @extend %button-content;
+        padding: spacing(offset, md);
+      }
+      &.is--icon-only{
+        .sd--icon {
+          width: spacing(inset, md) * 2;
+        }
+      }
+    }
+
+    &--lg {
+      font-size: rem(18);
+      min-height: spacing(inset, lg) * 2;
+      .sd--button__content {
+        @extend %button-content;
+        padding: spacing(offset, lg);
+      }
+      &.is--icon-only {
+        .sd--icon {
+          width: spacing(inset, lg) * 2;
+        }
+      }
+    }
+
+    &--xl {
+      font-size: rem(24);
+      min-height: spacing(inset, lg) * 2;
+      .sd--button__content {
+        @extend %button-content;
+        padding: spacing(offset, xl);
+      }
+      &.is--icon-only {
+        .sd--icon {
+          width: spacing(inset, lg) * 2;
+        }
+      }
+    }
+  }
+
   &.is--block {
     display: flex;
     width: 100%;
+    justify-content: center;
     & + & {
       margin: 0;
     }
   }
 
-  &:focus{
+  &:focus {
     outline: none;
   }
 
   &__content {
-    position: relative;
-    z-index: 10;
-    transition: font-size .23s;
-    padding-top:8px;
-    padding-bottom:8px;
-
-    &.is {
-      &--xs {
-        font-size: rem(12);
-        padding: spacing(inset, xs);
-      }
-      &--sm {
-        font-size: rem(14);
-        line-height: 1;
-        padding: spacing(inset, sm);
-      }
-
-      &--md {
-        font-size: rem(16);
-        line-height: 1;
-        padding: spacing(offset, md);
-      }
-
-      &--lg {
-        font-size: rem(18);
-        line-height: 1;
-        padding: spacing(offset, lg);
-      }
-
-      &--xl {
-        font-size: rem(24);
-        line-height: 1;
-        padding: spacing(offset, xl);
-      }
-    }
+    @extend %button-content;
   }
 
   @each $state, $color in $sd-color-global {
@@ -290,14 +363,14 @@ export default defineComponent({
         transition: all .13s ease-out;
       }
 
-      &.is--active, &.is--exact-active{
+      &.is--active, &.is--exact-active {
         @include elevation(6);
         color: var(--#{$state}-highlight-text);
         background-color: var(--#{$state}-highlight);
         transition: all .13s ease-out;
       }
 
-      &.is--disabled{
+      &.is--disabled {
         background-color: var(--disabled-background);
         color: var(--disabled);
         @include elevation(0);
@@ -336,71 +409,56 @@ export default defineComponent({
     }
 
     &.is--pill {
-      border-radius: 60px;
-      .sd--icon + .sd--button__content{
-        padding-left: 8px;
-      }
-      .sd--button__content + .sd--icon{
-        padding-right: 8px;
-      }
-      .sd--button__content {
+      border-radius: 30px;
+      .sd--button__content:only-child{
         padding-left: 20px;
         padding-right: 20px;
       }
     }
   }
-  // Handle Icons
 
-  .sd--icon{
-    line-height: 1px;
-    width:32px;
-    height:32px;
-    height: auto;
+  // Handle Icons
+  .sd--icon {
+    width: 32px;
     position: relative;
-    & + .sd--button__content{
-      padding-left:0px;
+    & + .sd--button__content {
+      padding-left: 0px;
     }
-    &:only-child{
+    &:only-child {
       margin-left:0!important;
     }
-    &.is{
+    &.is {
       &--xs {
         width: 20px;
-        height: 20px;
         &:last-child {
-          margin-left: spacing(inset, xs) * -1
+          margin-left: spacing(inset, xs) * -1;
         }
       }
-      &--sm{
+      &--sm {
         width: 30px;
-        height:30px;
         &:last-child {
-          margin-left: spacing(inset, sm) * -1
+          margin-left: spacing(inset, sm) * -1;
         }
       }
-      &--md{
+      &--md {
         width: 32px;
-        height:32px;
         &:last-child {
-          margin-left: spacing(inset, md) * -1
+          margin-left: spacing(inset, md) * -1;
         }
       }
-      &--lg{
+      &--lg {
         min-width: 42px;
-        min-height:42px;
         &:last-child {
-          margin-left: spacing(inset, lg) * -1
+          margin-left: spacing(inset, md) * -1;
         }
       }
-      &--xl{
+      &--xl {
         min-width: 56px;
-        min-height:56px;
-        &:last-child {
-          margin-left: spacing(inset, lg) * -1
+         &:last-child {
+          margin-left: spacing(inset, lg) * -1;
         }
       }
     }
   }
 }
-
 </style>

--- a/src/lib/components/SdIcon/SdIcon.vue
+++ b/src/lib/components/SdIcon/SdIcon.vue
@@ -25,11 +25,9 @@ export default defineComponent({
   setup (props) {
     const iconClasses = computed(() =>{
       const iconSize = `is--${props.size}`
-      const iconFamily = !props.family ? 'material-icons' : `material-icons-${props.family}`
-    return {
-      [iconFamily]: true,
-      [iconSize]: !!props.size
-    }
+      return {
+        [iconSize]: !!props.size
+      }
     })
     return { iconClasses }
   }

--- a/src/lib/components/SdIcon/SdIcon.vue
+++ b/src/lib/components/SdIcon/SdIcon.vue
@@ -14,9 +14,6 @@ export default defineComponent({
       type: String,
       default: 'face'
     },
-    family: {
-      type: String,
-    },
     size: {
       type: String,
       default: 'md'
@@ -40,9 +37,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-$material-icons-font-path: '~/material-icons/iconfont/';
-@import '~/material-icons/iconfont/material-icons.scss';
-
 $icon-sizes: (
   xs: 16px,
   sm: 18px,
@@ -51,15 +45,37 @@ $icon-sizes: (
   xl: 32px
 );
 
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/materialicons/v48/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2) format('woff2');
+}
+
 .sd--icon {
-  color: var(--text);
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: map-get($icon-sizes, md);
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  font-feature-settings: 'liga';
+  font-smooth: antialiased;
+}
+
+.sd--icon {
+  display:block;
   &.is{
     @each $size, $value in $icon-sizes{
       &--#{$size}{
         font-size: $value;
-        width: $value;
-        height: $value;
-        min-width: $value;
         line-height: 1;
       }
     }

--- a/src/lib/scss/_mixins.scss
+++ b/src/lib/scss/_mixins.scss
@@ -3,6 +3,7 @@
     @content;
   }
 }
+
 @mixin root-color-scheme($scheme) {
   @media(prefers-color-scheme: $scheme){
     :root{
@@ -57,22 +58,20 @@
       }
     }
     @include color-scheme(light) {
-      @include color-scheme(dark) {
-        color: var(--#{$theme}-accent);
-        background-color: none;
+      color: var(--#{$theme}-accent);
+      background-color: none;
+      svg {
+        fill: var(--#{$theme}-accent);
+      }
+      &:hover {
+        background-color: var(--#{$theme});
+        color: var(--#{$theme}-text);
         svg {
-          fill: var(--#{$theme}-accent);
+          fill: var(--#{$theme}-text);
         }
-        &:hover {
-          background-color: var(--#{$theme});
-          color: var(--#{$theme}-text);
-          svg {
-            fill: var(--#{$theme}-text);
-          }
-        }
-        &:active, &.is--active, &.is--exact-active {
-          background-color: var(--#{$theme}-highlight);
-        }
+      }
+      &:active, &.is--active, &.is--exact-active {
+        background-color: var(--#{$theme}-highlight);
       }
     }
   }
@@ -126,9 +125,7 @@
 @mixin ios-safe-area {
   @supports (padding: max(32px, 32px)) {
     padding:
-    0
-    m#{a}x(16px, env(safe-area-inset-left))
-    0
-    m#{a}x(16px, env(safe-area-inset-right));
+    0 max(16px, env(safe-area-inset-left))
+    0 max(16px, env(safe-area-inset-right));
   }
 }

--- a/src/lib/scss/_spacing.scss
+++ b/src/lib/scss/_spacing.scss
@@ -9,6 +9,7 @@ $space: (
   ),
   offset: (
     default: 8px 16px,
+    xs: 4px 4px,
     sm: 4px 8px,
     md: 8px 16px,
     lg: 16px 16px,

--- a/src/lib/scss/engine.scss
+++ b/src/lib/scss/engine.scss
@@ -1,10 +1,10 @@
-@import './variables';
-@import './reset';
 @import './functions';
+@import './get-contrast';
+@import './variables';
+@import './breakpoints';
 @import './mixins';
 @import './spacing';
-@import './get-contrast';
 @import './colors';
+@import './reset';
 @import './typography';
-@import './breakpoints';
 @import './scrollbar';

--- a/src/stories/SdIcon.stories.js
+++ b/src/stories/SdIcon.stories.js
@@ -7,16 +7,6 @@ export default {
     size: { 
       control: 'select', 
       options: SIZES
-    },
-    family: {
-      control: 'select',
-      options: [
-        null, 
-        'round',
-        'outlined',
-        'sharp',
-        'two-tone'
-      ]
     }
   }
 };

--- a/src/stories/SdIcon.stories.js
+++ b/src/stories/SdIcon.stories.js
@@ -1,0 +1,37 @@
+import SdIcon from '../lib/components/SdIcon/SdIcon.vue';
+import { SIZES } from './constants'
+export default {
+  title: 'Components/SdIcon',
+  component: SdIcon,
+  argTypes: {
+    size: { 
+      control: 'select', 
+      options: SIZES
+    },
+    family: {
+      control: 'select',
+      options: [
+        null, 
+        'round',
+        'outlined',
+        'sharp',
+        'two-tone'
+      ]
+    }
+  }
+};
+
+const Template = (args) => ({
+  components: { SdIcon },
+  setup() {
+    return { args };
+  },
+  template: `
+    <sd-icon 
+      v-bind="args"
+    />
+  `,
+});
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6873,11 +6873,6 @@ material-colors@^1.2.1:
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
   integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
-material-icons@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/material-icons/-/material-icons-0.5.4.tgz#c9e8e89d93b1172ecb68090e368ee7b7bffecc9c"
-  integrity sha512-5ycazkNmIOtV78Ff3WgvxQESoJuujdRm0cNbf18fmyJN20jHyqp9rpwi4EfQyGimag0ZLElxtVg3H9enIKdOOw==
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
- Refactor icon feature with buttons should be easier to read and less error prone in most edgecases.
- Reduced `css` size a bit by removing a repeated mixin (Further optimization possible).
- Adjust the way that sd-icon is sized to avoid weird bugs.